### PR TITLE
Fix build errors

### DIFF
--- a/cmake/detect_gl.cmake
+++ b/cmake/detect_gl.cmake
@@ -18,10 +18,15 @@ if(NOT IS_DIRECTORY "${MY_3RDPARTY}/glm")
   message(FATAL_ERROR "MY_3RDPARTY/glm not exists: ${MY_3RDPARTY}/glm")
 endif()
 
+# glut
+
+find_package(GLUT REQUIRED)
+
 # GL_INCLUDE_DIRS
 
 set(GL_INCLUDE_DIRS
   ${GLFW3_INCLUDE_DIRS}
+  ${GLUT_INCLUDE_DIRS}
   ${MY_3RDPARTY}/glm
 )
 

--- a/samples/pdf/pdf_render.cc
+++ b/samples/pdf/pdf_render.cc
@@ -111,7 +111,7 @@ void PdfRenderPage(const std::string &pdf_name, FPDF_DOCUMENT doc, int index) {
     auto t_write = t.Elapsed();
 
     fprintf(stdout, "%s\n", img_name);
-    fprintf(stdout, " %02d: %dx%d, render=%lldms, write=%lldms\n",
+    fprintf(stdout, " %02d: %dx%d, render=%ldms, write=%ldms\n",
         index, width, height, t_render, t_write);
   } else {
     fprintf(stderr, "Page was too large to be rendered.\n");

--- a/src/base/image.cc
+++ b/src/base/image.cc
@@ -124,7 +124,9 @@ int Image::GetBytesPerPixel(const Format &format) {
     case Format::BGRA:  return 4;
     case Format::RGB:   return 3;
     case Format::RGBA:  return 4;
-    default: LOG(FATAL) << "Unaccepted format";
+    default:
+      LOG(FATAL) << "Unaccepted format";
+      return 0;
   }
 }
 

--- a/src/ui/base/glfw.hpp
+++ b/src/ui/base/glfw.hpp
@@ -5,3 +5,4 @@
 #endif
 #define GLFW_INCLUDE_GLCOREARB
 #include <GLFW/glfw3.h>
+#include <GL/glut.h>

--- a/src/ui/gl/gl.h
+++ b/src/ui/gl/gl.h
@@ -25,7 +25,7 @@
 # if defined(MY_GL_INCLUDE_GLCOREARB)
 #  include <GL/glcorearb.h>
 # elif !defined(MY_GL_INCLUDE_NONE)
-#  include <GL/gl.h>
+#  include <GL/glew.h>
 #  if defined(MY_GL_INCLUDE_GLEXT)
 #   include <GL/glext.h>
 #  endif

--- a/src/ui/gl/gl.h
+++ b/src/ui/gl/gl.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define MY_GL_INCLUDE_GLCOREARB
+//#define MY_GL_INCLUDE_GLCOREARB
 #define MY_GL_INCLUDE_GLEXT
 // #define MY_GL_INCLUDE_GLU
 // #define MY_GL_INCLUDE_NONE


### PR DESCRIPTION
fix build on linux

<details>
<summary>
build script
</summary>

[pdfium-reader.nix](https://github.com/milahu/nur-packages/blob/master/pkgs/applications/office/pdfium-reader/pdfium-reader.nix)

```nix
{ lib
, stdenv
, fetchFromGitHub
, cmake
, pdfium
, glfw
, glew
, xorg
, pkg-config
, gtk3
#, pcre2 # for gtk3
#, utillinux # mount for gtk3
, freeglut # GL/glut.h
, wrapGAppsHook
}:

stdenv.mkDerivation rec {
  pname = "pdfium-reader";
  version = "unstable-2023-08-25";

  src = fetchFromGitHub {
    /*
    owner = "ikuokuo";
    repo = "pdfium-reader";
    rev = "635ef925f288dcd8fdf684e62edf2bcb44379648";
    hash = "sha256-dBmbVpRiOWunvGO9VbPJc6fkduD0ekUUiMJV2qh3OVQ=";
    */
    owner = "milahu";
    repo = "pdfium-reader";
    rev = "2644cfe868a5a80b1df1987c4e048f0d336d310d";
    hash = "sha256-3InaH7/ydKMk+GgSq203ZzU5tUC2Z2J+Gakg9DoC8aI=";
    # TODO avoid git modules. create update.sh to generate sources.json
    # and merge sources trees in unpackPhase
    # https://github.com/ikuokuo/pdfium-reader/tree/main/third_party
    fetchSubmodules = true;
  };

  # TODO use system's libpdfium.so
  # patch CMakeLists.txt: set(PDFium_DIR ${MY_3RDPARTY}/pdfium-${HOST_OS}-${HOST_ARCH})
  postPatch = ''
    ln -s ${pdfium} third_party/pdfium-linux-x64
  '';

  nativeBuildInputs = [
    cmake
    pkg-config
    # fix: pdfium_reader: GLib-GIO-ERROR: No GSettings schemas are installed on the system
    wrapGAppsHook
  ];

  buildInputs = [
    pdfium
    glfw
    glew
    xorg.libX11
    xorg.libXxf86vm
    gtk3
    #pcre2 # for gtk3
    #utillinux # mount for gtk3
    freeglut # GL/glut.h
  ];

  meta = with lib; {
    description = "PDFium Reader";
    homepage = "https://github.com/ikuokuo/pdfium-reader";
    license = licenses.bsd3;
    maintainers = with maintainers; [ ];
  };
}
```

</details>


<details>
<summary>
build log
</summary>

```
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/mvv1k9371f5kkaq6kzpz06vaiy0wq757-source
source root is source
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
fixing cmake files...
cmake flags: -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DCMAKE_INSTALL_LOCALEDIR=/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/share/locale -DCMAKE_INSTALL_LIBEXECDIR=/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/libexec -DCMAKE_INSTALL_LIBDIR=/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/lib -DCMAKE_INSTALL_DOCDIR=/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/share/doc/pdfium-reader -DCMAKE_INSTALL_INFODIR=/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/share/info -DCMAKE_INSTALL_MANDIR=/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/share/man -DCMAKE_INSTALL_OLDINCLUDEDIR=/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/include -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/include -DCMAKE_INSTALL_SBINDIR=/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/sbin -DCMAKE_INSTALL_BINDIR=/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin -DCMAKE_INSTALL_NAME_DIR=/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/lib -DCMAKE_POLICY_DEFAULT_CMP0025=NEW -DCMAKE_OSX_SYSROOT= -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_STRIP=/nix/store/8phn3d072kcfvwvf6p5ys8pk8yxh236x-gcc-wrapper-12.3.0/bin/strip -DCMAKE_RANLIB=/nix/store/8phn3d072kcfvwvf6p5ys8pk8yxh236x-gcc-wrapper-12.3.0/bin/ranlib -DCMAKE_AR=/nix/store/8phn3d072kcfvwvf6p5ys8pk8yxh236x-gcc-wrapper-12.3.0/bin/ar -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_INSTALL_PREFIX=/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25  
-- The C compiler identification is GNU 12.3.0
-- The CXX compiler identification is GNU 12.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /nix/store/8phn3d072kcfvwvf6p5ys8pk8yxh236x-gcc-wrapper-12.3.0/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /nix/store/8phn3d072kcfvwvf6p5ys8pk8yxh236x-gcc-wrapper-12.3.0/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- HOST_OS: linux
-- HOST_ARCH: x64
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Found GLFW3: /nix/store/wdxrgwv24rj0nyyvzk9wncfcfhwcm2ca-glfw-3.3.8/lib/libglfw.so  
-- Found GLUT: /nix/store/5d6kzb2hsirwfjiiz8c91ahd2jb4yf17-freeglut-3.4.0/lib/libglut.so  
-- Found OpenGL: /nix/store/gx7s27xmdyhn66975q9hymq0dqbx640c-libGL-1.6.0/lib/libOpenGL.so   
-- Found X11: /nix/store/lsswsq8jycq3zrpmg31c71635dxlfmbg-xorgproto-2021.5/include   
-- Looking for XOpenDisplay in /nix/store/nwym4ys464vziikfjwmc9ngamcfaygvm-libX11-1.8.4/lib/libX11.so;/nix/store/bnpy6ypmsi21gym32qj8yb26sbsmf8bq-libXext-1.3.4/lib/libXext.so
-- Looking for XOpenDisplay in /nix/store/nwym4ys464vziikfjwmc9ngamcfaygvm-libX11-1.8.4/lib/libX11.so;/nix/store/bnpy6ypmsi21gym32qj8yb26sbsmf8bq-libXext-1.3.4/lib/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Looking for IceConnectionNumber in ICE
-- Looking for IceConnectionNumber in ICE - found
-- GL_INCLUDE_DIRS: /nix/store/wdxrgwv24rj0nyyvzk9wncfcfhwcm2ca-glfw-3.3.8/include;/nix/store/qpy8w7cxii6bx2ra80a5izy7in3m9x39-freeglut-3.4.0-dev/include;/build/source/third_party/glm
-- GL_LIBS: /nix/store/wdxrgwv24rj0nyyvzk9wncfcfhwcm2ca-glfw-3.3.8/lib/libglfw.so;X11;Xrandr;Xinerama;Xi;Xxf86vm;Xcursor;GL;dl;pthread
-- ImGui_DIR: /build/source/third_party/imgui
-- NFD_DIR: /build/source/third_party/nativefiledialog
nfd Platform: PLATFORM_LINUX
nfd Compiler: COMPILER_GNU
-- Found PkgConfig: /nix/store/hshdgh469175gqra1jaw1vgl0i9icjdh-pkg-config-wrapper-0.29.2/bin/pkg-config (found version "0.29.2") 
-- Checking for module 'gtk+-3.0'
--   Found gtk+-3.0, version 3.24.38
Package libpcre2-8 was not found in the pkg-config search path.
Perhaps you should add the directory containing `libpcre2-8.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libpcre2-8', required by 'glib-2.0', not found
Package libpcre2-8 was not found in the pkg-config search path.
Perhaps you should add the directory containing `libpcre2-8.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libpcre2-8', required by 'glib-2.0', not found
Package libpcre2-8 was not found in the pkg-config search path.
Perhaps you should add the directory containing `libpcre2-8.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libpcre2-8', required by 'glib-2.0', not found
Package libpcre2-8 was not found in the pkg-config search path.
Perhaps you should add the directory containing `libpcre2-8.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libpcre2-8', required by 'glib-2.0', not found
Using GTK version: 3.24.38
-- PDFium libs path: /build/source/third_party/pdfium-linux-x64
-- PDFium libs found
-- Found PDFium: /nix/store/pbssqvk3ivdc4n2zyvpw1mcj91r7c041-pdfium-bin-5961/lib/libpdfium.so (found version "118.0.5961.0") 
-- Found GLEW: /nix/store/vp9jar8rps95h262v9gdlybj2j1j2qw6-glew-2.2.0-dev/lib/cmake/glew/glew-config.cmake  
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_TESTING
    CMAKE_EXPORT_NO_PACKAGE_REGISTRY
    CMAKE_POLICY_DEFAULT_CMP0025


-- Build files have been written to: /build/source/build
cmake: enabled parallel building
cmake: enabled parallel installing
@nix { "action": "setPhase", "phase": "buildPhase" }
building
build flags: -j3 SHELL=/nix/store/mh1c3p23xby3chc3q0c0g78fa1nn65yw-bash-5.2-p15/bin/bash
[  2%] Building CXX object third_party/nativefiledialog/src/CMakeFiles/nfd.dir/nfd_gtk.cpp.o
[  5%] Building CXX object CMakeFiles/imgui.dir/third_party/imgui/imgui.cpp.o
[  8%] Building C object samples/CMakeFiles/pdfium_start.dir/pdfium_start.c.o
[ 10%] Linking C executable /build/source/_output/bin/pdfium_start
[ 10%] Built target pdfium_start
[ 13%] Building CXX object CMakeFiles/imgui.dir/third_party/imgui/imgui_demo.cpp.o
[ 16%] Linking CXX static library libnfd.a
[ 16%] Built target nfd
[ 18%] Building CXX object CMakeFiles/imgui.dir/third_party/imgui/imgui_draw.cpp.o
[ 21%] Building CXX object CMakeFiles/imgui.dir/third_party/imgui/imgui_tables.cpp.o
[ 24%] Building CXX object samples/pdf/CMakeFiles/pdf_info.dir/pdf_info.cc.o
[ 27%] Building CXX object CMakeFiles/imgui.dir/third_party/imgui/imgui_widgets.cpp.o
[ 29%] Building CXX object samples/pdf/CMakeFiles/pdf_info.dir/helper.cc.o
[ 32%] Linking CXX executable /build/source/_output/bin/pdf/pdf_info
[ 35%] Building CXX object CMakeFiles/imgui.dir/third_party/imgui/backends/imgui_impl_glfw.cpp.o
[ 35%] Built target pdf_info
[ 37%] Building CXX object CMakeFiles/imgui.dir/third_party/imgui/backends/imgui_impl_opengl3.cpp.o
[ 40%] Building CXX object samples/pdf/CMakeFiles/pdf_render.dir/pdf_render.cc.o
[ 43%] Building CXX object samples/pdf/CMakeFiles/pdf_render.dir/helper.cc.o
[ 45%] Building CXX object samples/ui/CMakeFiles/glfw_demo.dir/__/__/src/ui/base/glfw_base.cc.o
[ 48%] Linking CXX executable /build/source/_output/bin/pdf/pdf_render
[ 51%] Building CXX object samples/ui/CMakeFiles/glfw_demo.dir/glfw_demo.cc.o
[ 51%] Built target pdf_render
[ 54%] Linking CXX executable /build/source/_output/bin/ui/glfw_demo
[ 54%] Built target glfw_demo
[ 56%] Linking CXX static library libimgui.a
[ 56%] Built target imgui
[ 59%] Building CXX object samples/ui/CMakeFiles/imgui_demo.dir/__/__/src/ui/base/imgui_base.cc.o
[ 62%] Building CXX object samples/ui/CMakeFiles/imgui_demo.dir/__/__/src/ui/base/glfw_base.cc.o
[ 64%] Building CXX object CMakeFiles/pdfium_reader.dir/src/main.cc.o
[ 67%] Building CXX object samples/ui/CMakeFiles/imgui_demo.dir/imgui_demo.cc.o
[ 70%] Building CXX object CMakeFiles/pdfium_reader.dir/src/base/image.cc.o
[ 72%] Building CXX object CMakeFiles/pdfium_reader.dir/src/pdf/pdfdocument.cc.o
[ 75%] Linking CXX executable /build/source/_output/bin/ui/imgui_demo
[ 75%] Built target imgui_demo
[ 78%] Building CXX object CMakeFiles/pdfium_reader.dir/src/pdf/pdfglobal.cc.o
[ 81%] Building CXX object CMakeFiles/pdfium_reader.dir/src/pdf/pdfloader.cc.o
[ 83%] Building CXX object CMakeFiles/pdfium_reader.dir/src/ui/base/glfw_base.cc.o
[ 86%] Building CXX object CMakeFiles/pdfium_reader.dir/src/ui/base/imgui_base.cc.o
[ 89%] Building CXX object CMakeFiles/pdfium_reader.dir/src/ui/native/filedialog_nfd.cc.o
[ 91%] Building CXX object CMakeFiles/pdfium_reader.dir/src/ui/native/native_nfd.cc.o
[ 94%] Building CXX object CMakeFiles/pdfium_reader.dir/src/ui/page.cc.o
[ 97%] Building CXX object CMakeFiles/pdfium_reader.dir/src/ui/ui.cc.o
[100%] Linking CXX executable /build/source/_output/bin/pdfium_reader
[100%] Built target pdfium_reader
buildPhase completed in 3 minutes 5 seconds
@nix { "action": "setPhase", "phase": "glibPreInstallPhase" }
glibPreInstallPhase
@nix { "action": "setPhase", "phase": "glibPreInstallPhase" }
glibPreInstallPhase
@nix { "action": "setPhase", "phase": "glibPreInstallPhase" }
glibPreInstallPhase
@nix { "action": "setPhase", "phase": "installPhase" }
installing
install flags: -j3 SHELL=/nix/store/mh1c3p23xby3chc3q0c0g78fa1nn65yw-bash-5.2-p15/bin/bash gsettingsschemadir=/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/share/gsettings-schemas/pdfium-reader-unstable-2023-08-25/glib-2.0/schemas/ gsettingsschemadir=/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/share/gsettings-schemas/pdfium-reader-unstable-2023-08-25/glib-2.0/schemas/ gsettingsschemadir=/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/share/gsettings-schemas/pdfium-reader-unstable-2023-08-25/glib-2.0/schemas/ install
[  5%] Built target pdfium_start
[ 10%] Built target nfd
[ 32%] Built target imgui
[ 40%] Built target pdf_info
[ 48%] Built target pdf_render
[ 56%] Built target glfw_demo
[ 67%] Built target imgui_demo
[100%] Built target pdfium_reader
Install the project...
-- Install configuration: "Release"
-- Installing: /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/pdfium_reader
-- Installing: /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/libpdfium.so
-- Installing: /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/lib/libnfd.a
-- Installing: /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/include/nfd.h
-- Installing: /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/include/nfd.hpp
-- Installing: /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/pdfium_start
-- Installing: /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/pdf/pdf_info
-- Installing: /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/pdf/pdf_render
-- Installing: /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/ui/glfw_demo
-- Installing: /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/ui/imgui_demo
@nix { "action": "setPhase", "phase": "glibPreFixupPhase" }
glibPreFixupPhase
@nix { "action": "setPhase", "phase": "glibPreFixupPhase" }
glibPreFixupPhase
@nix { "action": "setPhase", "phase": "glibPreFixupPhase" }
glibPreFixupPhase
@nix { "action": "setPhase", "phase": "gappsWrapperArgsHook" }
gappsWrapperArgsHook
@nix { "action": "setPhase", "phase": "dropIconThemeCache" }
dropIconThemeCache
@nix { "action": "setPhase", "phase": "dropIconThemeCache" }
dropIconThemeCache
@nix { "action": "setPhase", "phase": "dropIconThemeCache" }
dropIconThemeCache
@nix { "action": "setPhase", "phase": "fixupPhase" }
post-installation fixup
Wrapping program '/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/pdfium_reader'
Wrapping program '/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/ui/glfw_demo'
Wrapping program '/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/ui/imgui_demo'
Wrapping program '/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/pdfium_start'
Wrapping program '/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/pdf/pdf_info'
Wrapping program '/nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/pdf/pdf_render'
shrinking RPATHs of ELF executables and libraries in /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25
shrinking /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/pdfium_reader
shrinking /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/ui/glfw_demo
shrinking /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/ui/.glfw_demo-wrapped
shrinking /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/ui/.imgui_demo-wrapped
shrinking /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/ui/imgui_demo
shrinking /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/pdfium_start
shrinking /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/.pdfium_start-wrapped
shrinking /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/.pdfium_reader-wrapped
shrinking /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/pdf/.pdf_info-wrapped
shrinking /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/pdf/pdf_info
shrinking /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/pdf/pdf_render
shrinking /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/pdf/.pdf_render-wrapped
shrinking /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin/libpdfium.so
checking for references to /build/ in /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25...
patching script interpreter paths in /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25
stripping (with command strip and flags -S -p) in  /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/lib /nix/store/87cwlhjifnq3jvrm5369y3llhv1ha5r4-pdfium-reader-unstable-2023-08-25/bin
```

</details>


<details>
<summary>
screenshot
</summary>

![pdfium-reader Screenshot_20230825_154513](https://github.com/ikuokuo/pdfium-reader/assets/12958815/e9ba1605-3004-42bd-8bf4-f5ac53b17821)

</details>
